### PR TITLE
Keep the original usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 coverage/
 *.iml
 yarn-error.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "deepmerge": "^2.1.1",
-    "electron-store": "^2.0.0"
+    "electron-store": "^2.0.0",
+    "fast-deep-equal": "^2.0.1"
   }
 }

--- a/tests/shared-mutations.test.js
+++ b/tests/shared-mutations.test.js
@@ -71,7 +71,7 @@ describe("createSharedMutations", () => {
     }).not.toThrow()
   })
 
-  it("does not allow to use commit in renderer mode", () => {
+  it("allows to use commit in renderer mode", () => {
     const store = createStore({
       sharedMutations: {
         type: "renderer",
@@ -82,7 +82,7 @@ describe("createSharedMutations", () => {
 
     expect(() => {
       store.commit("increment")
-    }).toThrow()
+    }).not.toThrow()
   })
 
   it("allows to use dispatch in main mode", () => {


### PR DESCRIPTION
There are no restrictions on the `commit` and `dispatch` of the store, which is consistent with the original usage.
Fixes #8 #14 