### PR TITLE
Update README(yarn command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installation of the Vuex Electron easy as 1-2-3.
 1. Install package with using of [yarn](https://github.com/yarnpkg/yarn) or [npm](https://github.com/npm/cli):
 
     ```
-    yarn install vuex-electron
+    yarn add vuex-electron 
     ```
 
     or


### PR DESCRIPTION
I got an error when I ran the yarn command.

error: `install` has been replaced with `add` to add new dependencies. Run "yarn add vuex-electron" instead.

Modify the yarn command.