### PR TITLE
Bump electron-store from 2.0.0 to 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "deepmerge": "^2.1.1",
-    "electron-store": "^2.0.0"
+    "electron-store": "^6.0.1"
   }
 }


### PR DESCRIPTION
update electron-store version. deploying a windows app using electron-store 2.0 has dependencies that have since been updated that cause file system errors.