### PR TITLE
Update yarn installation instructions for package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installation of the Vuex Electron easy as 1-2-3.
 1. Install package with using of [yarn](https://github.com/yarnpkg/yarn) or [npm](https://github.com/npm/cli):
 
     ```
-    yarn install vuex-electron
+    yarn add vuex-electron
     ```
 
     or


### PR DESCRIPTION
When trying to run the command to install `vuex-electron` via yarn, you'll get an error in the terminal now since yarn as replaced `install` with the `add` keyword. 

Example of the error returned is as follows:
```
error `install` has been replaced with `add` to add new dependencies. Run "yarn add vuex-electron" instead.
```